### PR TITLE
minor-minor: just don't break blog links

### DIFF
--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -26,7 +26,7 @@ export default class IndexPage extends React.Component {
                   {data.description}
                   <br />
                   <br />
-                  <Link className="button is-small" to={data.slug}>
+                  <Link className="button is-small" to={'blog/' + data.slug}>
                     Keep Reading →
                   </Link>
                 </p>


### PR DESCRIPTION
Awesome repo, i really like gatsby (+ netlify-cms) and i'm anxious to give parcel a try, so this looks like the right path to me (:

About the change:
on homepage, clicking each article title leads us to the right`'blog/' + data.slug` url
but clicking on `keep reading` give us a 404, because it was just `data.slug`.


Thanks for your time